### PR TITLE
Add protected member page with token refresh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ VITE_FIREBASE_PROJECT_ID=your-project-id
 VITE_FIREBASE_STORAGE_BUCKET=your-storage-bucket
 VITE_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
 VITE_FIREBASE_APP_ID=your-app-id
+VITE_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Authentication.
    npm install
    ```
 
-2. Copy the `.env.example` file and fill in your Firebase credentials
+2. Copy the `.env.example` file and fill in your Firebase and API credentials
 
    ```bash
    cp .env.example .env
-   # edit .env with your values
+   # edit .env with your values, including `VITE_API_BASE_URL`
    ```
 
 3. Start the dev server

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Product from './pages/Product';
+import Member from './pages/Member';
 
 function App() {
   return (
@@ -12,6 +13,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/product" element={<Product />} />
+        <Route path="/member" element={<Member />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,0 +1,97 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { auth, provider } from './firebase';
+import {
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+  type User as FirebaseUser,
+} from 'firebase/auth';
+import {
+  getStoredAccessToken,
+  loginWithGoogle,
+  refreshAccessToken,
+  setAccessToken,
+} from './api';
+
+interface AuthContextValue {
+  user: FirebaseUser | null;
+  backendUser: unknown | null;
+  accessToken: string | null;
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  fetchWithAuth: (
+    input: RequestInfo | URL,
+    init?: RequestInit & { retry?: boolean },
+  ) => Promise<Response>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<FirebaseUser | null>(null);
+  const [backendUser, setBackendUser] = useState<unknown | null>(null);
+  const [accessToken, setTokenState] = useState<string | null>(
+    getStoredAccessToken(),
+  );
+
+  useEffect(() => {
+    setAccessToken(accessToken);
+  }, [accessToken]);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, (current) => {
+      setUser(current);
+    });
+  }, []);
+
+  const login = async () => {
+    const result = await signInWithPopup(auth, provider);
+    const idToken = await result.user.getIdToken();
+    const userData = await loginWithGoogle(idToken);
+    setBackendUser(userData);
+    setTokenState(getStoredAccessToken());
+  };
+
+  const logout = async () => {
+    await signOut(auth);
+    setBackendUser(null);
+    setTokenState(null);
+    setAccessToken(null);
+  };
+
+  const fetchWithAuth: AuthContextValue['fetchWithAuth'] = async (
+    input,
+    init = {},
+  ) => {
+    const headers = new Headers(init.headers);
+    if (accessToken) {
+      headers.set('Authorization', `Bearer ${accessToken}`);
+    }
+    init.headers = headers;
+    init.credentials = 'include';
+    const resp = await fetch(input, init);
+    if (resp.status === 401 && init.retry !== false) {
+      await refreshAccessToken();
+      setTokenState(getStoredAccessToken());
+      return fetchWithAuth(input, { ...init, retry: false });
+    }
+    return resp;
+  };
+
+  const value: AuthContextValue = {
+    user,
+    backendUser,
+    accessToken,
+    login,
+    logout,
+    fetchWithAuth,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -45,11 +45,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const login = async () => {
-    const result = await signInWithPopup(auth, provider);
-    const idToken = await result.user.getIdToken();
-    const userData = await loginWithGoogle(idToken);
-    setBackendUser(userData);
-    setTokenState(getStoredAccessToken());
+    try {
+      const result = await signInWithPopup(auth, provider);
+      const idToken = await result.user.getIdToken();
+      const userData = await loginWithGoogle(idToken);
+      setBackendUser(userData);
+      setTokenState(getStoredAccessToken());
+    } catch (err) {
+      await logout();
+      throw err;
+    }
   };
 
   const logout = async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,71 @@
+const requiredEnvVars = ['VITE_API_BASE_URL'] as const;
+for (const key of requiredEnvVars) {
+  if (!import.meta.env[key]) {
+    throw new Error(`Missing API environment variable: ${key}`);
+  }
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+
+export async function apiFetch<T>(
+  path: string,
+  options: RequestInit & { auth?: boolean; retry?: boolean } = {},
+): Promise<T> {
+  const { auth, retry = true, ...init } = options;
+  const headers = new Headers(init.headers);
+  if (auth && accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+  }
+  init.headers = headers;
+  init.credentials = 'include';
+
+  const resp = await fetch(`${API_BASE_URL}${path}`, init);
+
+  if (resp.status === 401 && retry && auth) {
+    await refreshAccessToken();
+    return apiFetch(path, { ...options, retry: false });
+  }
+
+  if (!resp.ok) {
+    throw new Error(`Request failed with status ${resp.status}`);
+  }
+
+  return resp.json();
+}
+
+let accessToken: string | null = null;
+
+export function setAccessToken(token: string | null) {
+  accessToken = token;
+  if (token) {
+    localStorage.setItem('access_token', token);
+  } else {
+    localStorage.removeItem('access_token');
+  }
+}
+
+export function getStoredAccessToken() {
+  return localStorage.getItem('access_token');
+}
+
+export async function loginWithGoogle(idToken: string) {
+  const data = await apiFetch<{ data: { access_token: string; user: unknown } }>(
+    '/auth/google-login',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id_token: idToken }),
+    },
+  );
+  setAccessToken(data.data.access_token);
+  return data.data.user;
+}
+
+export async function refreshAccessToken() {
+  const data = await apiFetch<{ data: { access_token: string; user: unknown } }>(
+    '/auth/refresh-token',
+    { method: 'POST' },
+  );
+  setAccessToken(data.data.access_token);
+  return data.data.user;
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,9 @@ function Header() {
           <li>
             <Link to="/product">Product</Link>
           </li>
+          <li>
+            <Link to="/member">Member</Link>
+          </li>
         </ul>
       </nav>
     </header>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
 import ErrorBoundary from './components/ErrorBoundary.tsx';
+import { AuthProvider } from './AuthContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ErrorBoundary>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </ErrorBoundary>
   </StrictMode>,
 );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../AuthContext';
 
 function Login() {
-  const { user, login, logout } = useAuth();
+  const { user, backendUser, login, logout } = useAuth();
 
   const handleLogin = async () => {
     try {
@@ -18,7 +18,7 @@ function Login() {
   return (
     <div>
       <h2>Login</h2>
-      {user ? (
+      {user && backendUser ? (
         <>
           <p>👋 Hello, {user.displayName}</p>
           <button onClick={handleLogout}>登出</button>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,31 +1,18 @@
-import { useEffect, useState } from 'react';
-import { auth, provider } from '../firebase';
-import {
-  onAuthStateChanged,
-  signInWithPopup,
-  signOut,
-  type User,
-} from 'firebase/auth';
+import { useAuth } from '../AuthContext';
 
 function Login() {
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    return onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser);
-    });
-  }, []);
+  const { user, login, logout } = useAuth();
 
   const handleLogin = async () => {
     try {
-      await signInWithPopup(auth, provider);
+      await login();
     } catch (err) {
       console.error(err);
     }
   };
 
   const handleLogout = async () => {
-    await signOut(auth);
+    await logout();
   };
 
   return (

--- a/src/pages/Member.tsx
+++ b/src/pages/Member.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../AuthContext';
+
+function Member() {
+  const { backendUser } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!backendUser) {
+      navigate('/login', { replace: true });
+    }
+  }, [backendUser, navigate]);
+
+  if (!backendUser) return null;
+
+  return (
+    <div>
+      <h2>Member Page</h2>
+      <p>Welcome, {(backendUser as any).email}</p>
+    </div>
+  );
+}
+
+export default Member;


### PR DESCRIPTION
## Summary
- add API base URL to `.env.example`
- document new API env var in README
- implement API helpers and auth provider with token refresh
- require login on new `Member` page
- wire up auth provider in `main.tsx`
- update navigation for the member route

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684244064bcc8330a2958c54515cab60