### PR TITLE
Fix login greeting displayed when backend auth fails

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -45,11 +45,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const login = async () => {
-    const result = await signInWithPopup(auth, provider);
-    const idToken = await result.user.getIdToken();
-    const userData = await loginWithGoogle(idToken);
-    setBackendUser(userData);
-    setTokenState(getStoredAccessToken());
+    try {
+      const result = await signInWithPopup(auth, provider);
+      const idToken = await result.user.getIdToken();
+      const userData = await loginWithGoogle(idToken);
+      setBackendUser(userData);
+      setTokenState(getStoredAccessToken());
+    } catch (err) {
+      await logout();
+      throw err;
+    }
   };
 
   const logout = async () => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '../AuthContext';
 
 function Login() {
-  const { user, login, logout } = useAuth();
+  const { user, backendUser, login, logout } = useAuth();
 
   const handleLogin = async () => {
     try {
@@ -18,7 +18,7 @@ function Login() {
   return (
     <div>
       <h2>Login</h2>
-      {user ? (
+      {user && backendUser ? (
         <>
           <p>👋 Hello, {user.displayName}</p>
           <button onClick={handleLogout}>登出</button>


### PR DESCRIPTION
## Summary
- handle errors in `login` by calling `logout` if backend login fails
- only show greeting when both Firebase and backend login succeed

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68425b0811c8833097edb12cf88c3949