### PR TITLE
Add BackendUser interface and tighten auth types

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -13,9 +13,14 @@ import {
   setAccessToken,
 } from './api';
 
+export interface BackendUser {
+  email: string;
+  [key: string]: unknown;
+}
+
 interface AuthContextValue {
   user: FirebaseUser | null;
-  backendUser: unknown | null;
+  backendUser: BackendUser | null;
   accessToken: string | null;
   login: () => Promise<void>;
   logout: () => Promise<void>;
@@ -29,7 +34,7 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<FirebaseUser | null>(null);
-  const [backendUser, setBackendUser] = useState<unknown | null>(null);
+  const [backendUser, setBackendUser] = useState<BackendUser | null>(null);
   const [accessToken, setTokenState] = useState<string | null>(
     getStoredAccessToken(),
   );

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+import type { BackendUser } from './AuthContext';
+
 const requiredEnvVars = ['VITE_API_BASE_URL'] as const;
 for (const key of requiredEnvVars) {
   if (!import.meta.env[key]) {
@@ -48,8 +50,8 @@ export function getStoredAccessToken() {
   return localStorage.getItem('access_token');
 }
 
-export async function loginWithGoogle(idToken: string) {
-  const data = await apiFetch<{ data: { access_token: string; user: unknown } }>(
+export async function loginWithGoogle(idToken: string): Promise<BackendUser> {
+  const data = await apiFetch<{ data: { access_token: string; user: BackendUser } }>(
     '/auth/google-login',
     {
       method: 'POST',
@@ -61,8 +63,8 @@ export async function loginWithGoogle(idToken: string) {
   return data.data.user;
 }
 
-export async function refreshAccessToken() {
-  const data = await apiFetch<{ data: { access_token: string; user: unknown } }>(
+export async function refreshAccessToken(): Promise<BackendUser> {
+  const data = await apiFetch<{ data: { access_token: string; user: BackendUser } }>(
     '/auth/refresh-token',
     { method: 'POST' },
   );

--- a/src/pages/Member.tsx
+++ b/src/pages/Member.tsx
@@ -17,7 +17,7 @@ function Member() {
   return (
     <div>
       <h2>Member Page</h2>
-      <p>Welcome, {(backendUser as any).email}</p>
+      <p>Welcome, {backendUser.email}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- define `BackendUser` type for backend user data
- use `BackendUser` in auth context
- update API helpers to return typed backend user
- simplify `Member` page by removing casts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842912d24c48330ac75bd889ebdd09a